### PR TITLE
Allow global view for logical hierarchy

### DIFF
--- a/app/workvisualizer/app/dashboard/page.tsx
+++ b/app/workvisualizer/app/dashboard/page.tsx
@@ -29,7 +29,6 @@ let maximum_depth = 1
 
 export default function Page() {
     const [selectedPlot, setSelectedPlot] = useState<string[]>([]);
-    const [invalidPlot, setInvalidPlot] = useState(false);
     const [selectedRank, setSelectedRank] = useState("0");
     const [inputValue, setInputValue] = useState("");
     const [invalidRank, setInvalidRank] = useState(false);
@@ -67,10 +66,8 @@ export default function Page() {
         const plotName = e.target.value;
         console.log(plotName);
         if (allSelected && plotName == "spaceTime") {
-            setInvalidPlot(true);
             setSelectedPlot(['']);
         } else {
-            setInvalidPlot(false);
             setSelectedPlot([plotName])
             if (plotName == "logicalSunBurst") {
                 setSunburstSelected(true);
@@ -193,9 +190,9 @@ export default function Page() {
                         variant="bordered"
                         placeholder="Select plots"
                         onChange={handlePlotSelection}
+                        disabledKeys={allSelected ? ["spaceTime"] : []}
                         className="min-w-full pt-4"
-                        isInvalid={invalidPlot ? true : false}
-                        errorMessage={invalidPlot ? "Spacetime diagram is not available for all ranks." : ""}
+                        // errorMessage={invalidPlot ? "Spacetime diagram is not available for all ranks." : ""}
                     >
                         {plots.filter(plot => plot.key !== 'globalIndentedTree' && plot.key !== 'summaryTable').map((plot) => (
                             <SelectItem key={plot.key}>{plot.plot.label}</SelectItem>


### PR DESCRIPTION
General notes:
- Default view is still Rank 0 for all visualizations
- If `Logical SunBurst` is selected, the `all` rank selector button is enabled
- If `Logical SunBurst` is not selected, the `all` rank selector button is disabled

- If `Logical SunBurst` is selected AND `all` is selected, and the user tries to switch to SpaceTime, the plot will disappear and an error message will show up.
  - The cleaner way to protect against this case is to simply disable `SpaceTime` in the `select` component when `all` is active. The problem with this is that there's no message/warning explaining why spacetime is disabled, so users may be confused.